### PR TITLE
update anchor-element mixin

### DIFF
--- a/app/styles/ice-box/mixins/_layout.scss
+++ b/app/styles/ice-box/mixins/_layout.scss
@@ -24,7 +24,7 @@
 // * $right = right alignment
 // * $bottom = bottom alignment
 // * $left = left alignment
-// * $position = optional position value, absolute by default
+// * $position = optional position value, absolute by default. Do not use quotes!
 //
 // ### Example Output:
 //   ```
@@ -45,7 +45,7 @@
 
 @mixin anchor-element($top: null, $right: null, $bottom: null, $left: null, $position: null) {
   @if $position {
-    position: unquote($position);
+    position: $position;
   } @else {
     position: absolute;
   }


### PR DESCRIPTION
This mixin, which I originally copied from the app css, is causing a deprecation warning there (I have a PR out for fixing it). I'm also fixing it here now, since its used by dropdowns in ice-pop, which is now in the app. 
I will also need to remove the duplicate one from the app at some point (same for any other functions/mixins I copied over)

@Addepar/ice 