### PR TITLE
reflect change in typography property that made sass-lint angry in product

### DIFF
--- a/app/styles/ice-box/mixins/_typography.scss
+++ b/app/styles/ice-box/mixins/_typography.scss
@@ -93,7 +93,6 @@
   * {
     text-rendering: optimizeLegibility;
 
-    font-smoothing: antialiased;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }


### PR DESCRIPTION
This property doesn't exist. Removed in product due to (future?) sass-lint error

@Addepar/ice @Addepar/design 