### PR TITLE
Refrain from using arrow functions in vendor file

### DIFF
--- a/vendor/ice-box/register-legacy-helpers.js
+++ b/vendor/ice-box/register-legacy-helpers.js
@@ -1,7 +1,7 @@
-Ember.HTMLBars._registerHelper('concat', Ember.HTMLBars.makeBoundHelper((params) => {
+Ember.HTMLBars._registerHelper('concat', Ember.HTMLBars.makeBoundHelper(function(params) {
   return params.join('');
 }));
 
-Ember.HTMLBars._registerHelper('hash', Ember.HTMLBars.makeBoundHelper((params, hash) => {
+Ember.HTMLBars._registerHelper('hash', Ember.HTMLBars.makeBoundHelper(function(params, hash) {
   return hash;
 }));


### PR DESCRIPTION
When using `app.import` API and including dependencies into the host
app, imported files don't get transpiled. That would lead to issues in
browsers which don't support latest JS syntax (IE 11).

Relevant links:

+ https://caniuse.com/#feat=arrow-functions